### PR TITLE
Add sound effect when using the absorption book

### DIFF
--- a/src/main/java/fathertoast/naturalabsorption/item/ItemAbsorptionBook.java
+++ b/src/main/java/fathertoast/naturalabsorption/item/ItemAbsorptionBook.java
@@ -6,6 +6,7 @@ import fathertoast.naturalabsorption.config.*;
 import fathertoast.naturalabsorption.health.*;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -67,9 +68,16 @@ class ItemAbsorptionBook extends Item
 				//noinspection ConstantConditions
 				player.addStat( StatList.getObjectUseStats( this ) );
 			}
+			
+			// play sound to show success
+	        player.playSound( SoundEvents.ENTITY_PLAYER_LEVELUP, 1f, 1f );
+	        
 			return ActionResult.newResult( EnumActionResult.SUCCESS, book );
 		}
 		
+		// tell the player why right click failed
+    	player.sendStatusMessage( new TextComponentTranslation( "item.naturalabsorption.book_absorption.not_enough_levels", levelCost ), true );
+    	
 		return ActionResult.newResult( EnumActionResult.FAIL, book );
 	}
 	

--- a/src/main/resources/assets/naturalabsorption/lang/en_us.lang
+++ b/src/main/resources/assets/naturalabsorption/lang/en_us.lang
@@ -7,5 +7,6 @@ item.naturalabsorption.book_absorption.tooltip.max=Max Absorption
 item.naturalabsorption.book_absorption.tooltip.cost=Cost: %d levels
 item.naturalabsorption.book_absorption.tooltip.canuse=Right click to use
 item.naturalabsorption.book_absorption.tooltip.nouse=You can't use this
+item.naturalabsorption.book_absorption.not_enough_levels=Requires at least %s levels to use
 
 enchantment.naturalabsorption.absorption=Absorption


### PR DESCRIPTION
First of two pull requests for features from Unnatural Absorption.

This makes absorption books play a sound when used. Additionally, if the player does not have enough levels when attempting to use an absorption book, a message appears above the hotbar telling them they need more levels.