### PR TITLE
Add config options for absorption hunger requirements

### DIFF
--- a/src/main/java/fathertoast/naturalabsorption/config/Config.java
+++ b/src/main/java/fathertoast/naturalabsorption/config/Config.java
@@ -135,6 +135,17 @@ class Config
 			"starting_absorption", 4.0F,
 			"The amount of natural absorption a new player starts with."
 		);
+		
+		public final float HUNGER_COST = prop(
+			"hunger_cost", 0F,
+			"The amount of hunger or saturation drained for each point of absorption health regenerated.\n" +
+			"Players can't lose more than 10 points of hunger or saturation at a time in this way."
+		) * 4.0F; // Conversion from hunger/health to exhaustion/health
+		
+		public final int HUNGER_REQUIRED = prop(
+			"hunger_required", 0,
+			"Players need to have at least this much hunger to regenerate absorption health."
+		);
 	}
 	
 	public final ABSORPTION_UPGRADES ABSORPTION_UPGRADES = new ABSORPTION_UPGRADES( );

--- a/src/main/java/fathertoast/naturalabsorption/health/HealthData.java
+++ b/src/main/java/fathertoast/naturalabsorption/health/HealthData.java
@@ -166,6 +166,11 @@ class HealthData
 			recovered = Config.get( ).ABSORPTION_HEALTH.RECOVER_RATE * Config.get( ).GENERAL.UPDATE_TIME;
 		}
 		
+		// Handle hunger cost restrictions
+		if( owner.getFoodStats( ).getFoodLevel( ) < Config.get( ).ABSORPTION_HEALTH.HUNGER_REQUIRED ) {
+			return;
+		}
+		
 		// Recover absorption health, if needed
 		float effectiveCapacity = getEffectiveCapacity( );
 		float currentAbsorption = owner.getAbsorptionAmount( );
@@ -181,7 +186,14 @@ class HealthData
 			}
 			
 			// Add absorption recovery
-			owner.setAbsorptionAmount( Math.min( effectiveCapacity, currentAbsorption + recovered ) );
+			
+			float newAbsorption = Math.min( effectiveCapacity, currentAbsorption + recovered );
+			owner.setAbsorptionAmount( newAbsorption );
+			
+			// consume hunger if needed
+			if ( newAbsorption - currentAbsorption > 0 && Config.get( ).ABSORPTION_HEALTH.HUNGER_COST > 0 ) {
+				owner.getFoodStats( ).addExhaustion( ( newAbsorption - currentAbsorption ) * Config.get( ).ABSORPTION_HEALTH.HUNGER_COST );
+			}
 		}
 	}
 	


### PR DESCRIPTION
Second of two pull requests for features from Unnatural Absorption.

This adds options for absorption to only recover if the hunger bar is at a specific level and to consume hunger when restoring absorption.